### PR TITLE
Fix build error if libray is build with CMake

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 #if defined(_WIN32) || defined(_WIN64)
  #define __FILENAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)


### PR DESCRIPTION
Error Output:
In file included from /home/urboro/_GIT/E90MVP/Core/3rdParty/c-logger/src/logger.c:1: /home/urboro/_GIT/E90MVP/Core/3rdParty/c-logger/src/logger.h:116:79: error: unknown type name ‘va_list’
  116 | void logger_vlog(LogLevel level, const char* file, int line, const char* fmt, va_list arg);